### PR TITLE
Add prompt form UI with validation and payload helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useState } from 'react';
+import PromptForm from './components/PromptForm';
+import { EnhancementPreset, ImageSizeOption, PromptRequestPayload } from './types/prompt';
+
+const enhancementPresets: EnhancementPreset[] = [
+  {
+    id: 'cinematic',
+    label: 'Cinematic',
+    description: 'Adds dramatic lighting and depth for filmic shots.',
+    promptEnhancement: (prompt) =>
+      `${prompt}\n\nEnhance with ultra-wide cinematic composition, volumetric lighting, and rich color grading.`,
+  },
+  {
+    id: 'illustrative',
+    label: 'Illustrative',
+    description: 'Great for stylised drawings and concept art.',
+    promptEnhancement: (prompt) =>
+      `${prompt}\n\nRender as a high-detail digital illustration with crisp linework and painterly shading.`,
+  },
+  {
+    id: 'photoreal',
+    label: 'Photo-realistic',
+    description: 'Optimised for lifelike photography outputs.',
+    promptEnhancement: (prompt) =>
+      `${prompt}\n\nGenerate with photo-realistic textures, natural light, and shallow depth of field.`,
+  },
+];
+
+const imageSizes: ImageSizeOption[] = [
+  { label: 'Square', width: 1024, height: 1024 },
+  { label: 'Portrait', width: 1024, height: 1344 },
+  { label: 'Landscape', width: 1344, height: 1024 },
+];
+
+const App: React.FC = () => {
+  const [lastRequest, setLastRequest] = useState<PromptRequestPayload | null>(null);
+
+  const handleSubmit = useCallback((payload: PromptRequestPayload) => {
+    setLastRequest(payload);
+    // This is where the Gemini request would be triggered.
+    // fetch('/api/gemini', { method: 'POST', body: JSON.stringify(payload) }) ...
+  }, []);
+
+  return (
+    <div className="app">
+      <header>
+        <h1>Text to Image Playground</h1>
+        <p>Create an expressive prompt, choose an enhancement, and toggle Nano Banana for extra flair.</p>
+      </header>
+      <PromptForm
+        presets={enhancementPresets}
+        sizeOptions={imageSizes}
+        maxPromptLength={600}
+        defaultNanoBanana
+        onSubmit={handleSubmit}
+      />
+      {lastRequest && (
+        <section className="app__last-request">
+          <h2>Last submitted payload</h2>
+          <pre>{JSON.stringify(lastRequest, null, 2)}</pre>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -1,0 +1,177 @@
+import React, { FormEvent } from 'react';
+import { usePromptForm } from '../hooks/usePromptForm';
+import { EnhancementPreset, ImageSizeOption, PromptRequestPayload } from '../types/prompt';
+
+export interface PromptFormProps {
+  presets: EnhancementPreset[];
+  sizeOptions: ImageSizeOption[];
+  maxPromptLength?: number;
+  defaultNanoBanana?: boolean;
+  onSubmit: (payload: PromptRequestPayload) => void;
+}
+
+export const PromptForm: React.FC<PromptFormProps> = ({
+  presets,
+  sizeOptions,
+  maxPromptLength,
+  defaultNanoBanana = false,
+  onSubmit,
+}) => {
+  const {
+    prompt,
+    setPrompt,
+    selectedPresetId,
+    setSelectedPresetId,
+    nanoBanana,
+    setNanoBanana,
+    selectedSize,
+    setSelectedSize,
+    errors,
+    enhancedPrompt,
+    payload,
+    maxPromptLength: limit,
+    handleSubmit,
+  } = usePromptForm({
+    presets,
+    sizeOptions,
+    maxPromptLength,
+    defaultNanoBanana,
+  });
+
+  const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleSubmit(onSubmit);
+  };
+
+  const characterCount = prompt.trim().length;
+  const characterLimit = maxPromptLength ?? limit;
+
+  return (
+    <form className="prompt-form" onSubmit={onFormSubmit} noValidate>
+      <fieldset>
+        <legend>Prompt</legend>
+        <label htmlFor="prompt-input" className="prompt-form__label">
+          Describe the image you want to generate
+        </label>
+        <textarea
+          id="prompt-input"
+          name="prompt"
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          rows={6}
+          aria-describedby="prompt-help prompt-error"
+          maxLength={characterLimit}
+          required
+        />
+        <div className="prompt-form__meta">
+          <small id="prompt-help">
+            {characterCount}/{characterLimit} characters used
+          </small>
+          {errors.prompt && (
+            <small id="prompt-error" role="alert" className="prompt-form__error">
+              {errors.prompt}
+            </small>
+          )}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Enhancement preset</legend>
+        <div className="prompt-form__enhancements">
+          {presets.map((preset) => (
+            <label key={preset.id} className="prompt-form__enhancement-option">
+              <input
+                type="radio"
+                name="enhancement"
+                value={preset.id}
+                checked={selectedPresetId === preset.id}
+                onChange={(event) => setSelectedPresetId(event.target.value)}
+                required
+              />
+              <span className="prompt-form__enhancement-label">{preset.label}</span>
+              {preset.description && (
+                <span className="prompt-form__enhancement-description">
+                  {preset.description}
+                </span>
+              )}
+            </label>
+          ))}
+        </div>
+        {errors.enhancementId && (
+          <small role="alert" className="prompt-form__error">
+            {errors.enhancementId}
+          </small>
+        )}
+      </fieldset>
+
+      <fieldset>
+        <legend>Nano Banana</legend>
+        <label className="prompt-form__toggle">
+          <input
+            type="checkbox"
+            checked={nanoBanana}
+            onChange={(event) => setNanoBanana(event.target.checked)}
+          />
+          <span>Activate Nano Banana prompt boost</span>
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Image size</legend>
+        <select
+          name="imageSize"
+          value={selectedSize ? `${selectedSize.width}x${selectedSize.height}` : ''}
+          onChange={(event) => {
+            const [width, height] = event.target.value.split('x').map(Number);
+            const matchedOption = sizeOptions.find(
+              (option) => option.width === width && option.height === height,
+            );
+            if (matchedOption) {
+              setSelectedSize(matchedOption);
+            }
+          }}
+          required
+        >
+          <option value="" disabled>
+            Choose a size
+          </option>
+          {sizeOptions.map((option) => (
+            <option
+              key={`${option.width}x${option.height}`}
+              value={`${option.width}x${option.height}`}
+            >
+              {option.label} ({option.width}×{option.height})
+            </option>
+          ))}
+        </select>
+        {errors.size && (
+          <small role="alert" className="prompt-form__error">
+            {errors.size}
+          </small>
+        )}
+      </fieldset>
+
+      <section className="prompt-form__preview">
+        <h2>Enhanced prompt preview</h2>
+        <pre>
+          {enhancedPrompt || prompt || 'Your enhanced prompt will appear here once you begin typing.'}
+        </pre>
+      </section>
+
+      <section className="prompt-form__payload">
+        <h2>Gemini request payload</h2>
+        <pre>
+          {payload
+            ? JSON.stringify(payload, null, 2)
+            : 'Complete the form to see the payload that will be sent to Gemini.'}
+        </pre>
+      </section>
+
+      <button type="submit" className="prompt-form__submit">
+        Generate with Gemini
+      </button>
+    </form>
+  );
+};
+
+export default PromptForm;

--- a/src/hooks/usePromptForm.ts
+++ b/src/hooks/usePromptForm.ts
@@ -1,0 +1,175 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  EnhancementPreset,
+  ImageSizeOption,
+  PromptRequestPayload,
+} from '../types/prompt';
+
+export interface PromptFormErrors {
+  prompt?: string;
+  enhancementId?: string;
+  size?: string;
+}
+
+export interface UsePromptFormOptions {
+  presets: EnhancementPreset[];
+  sizeOptions: ImageSizeOption[];
+  maxPromptLength?: number;
+  defaultNanoBanana?: boolean;
+}
+
+const DEFAULT_MAX_PROMPT_LENGTH = 600;
+
+export const usePromptForm = ({
+  presets,
+  sizeOptions,
+  maxPromptLength = DEFAULT_MAX_PROMPT_LENGTH,
+  defaultNanoBanana = false,
+}: UsePromptFormOptions) => {
+  const [prompt, setPrompt] = useState('');
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(
+    presets.length === 1 ? presets[0].id : null,
+  );
+  const [nanoBanana, setNanoBanana] = useState(defaultNanoBanana);
+  const [selectedSize, setSelectedSize] = useState<ImageSizeOption | null>(
+    sizeOptions.length > 0 ? sizeOptions[0] : null,
+  );
+  const [errors, setErrors] = useState<PromptFormErrors>({});
+
+  const trimmedPrompt = useMemo(() => prompt.trim(), [prompt]);
+
+  const presetMap = useMemo(
+    () => new Map(presets.map((preset) => [preset.id, preset])),
+    [presets],
+  );
+
+  const selectedPreset = useMemo(
+    () => (selectedPresetId ? presetMap.get(selectedPresetId) ?? null : null),
+    [presetMap, selectedPresetId],
+  );
+
+  const enhancedPrompt = useMemo(() => {
+    if (!trimmedPrompt) {
+      return '';
+    }
+
+    let workingPrompt = trimmedPrompt;
+
+    if (selectedPreset) {
+      workingPrompt = selectedPreset.promptEnhancement(trimmedPrompt);
+    }
+
+    if (nanoBanana) {
+      workingPrompt = `${workingPrompt}\n\nNano Banana Boost: please emphasize playful yellow highlights, whimsical lighting, and a vibrant surreal tone.`;
+    }
+
+    return workingPrompt;
+  }, [nanoBanana, selectedPreset, trimmedPrompt]);
+
+  const payload = useMemo<PromptRequestPayload | null>(() => {
+    if (!trimmedPrompt || !selectedSize) {
+      return null;
+    }
+
+    return {
+      prompt: enhancedPrompt || trimmedPrompt,
+      basePrompt: trimmedPrompt,
+      enhancementId: selectedPresetId,
+      nanoBanana,
+      width: selectedSize.width,
+      height: selectedSize.height,
+    };
+  }, [
+    enhancedPrompt,
+    nanoBanana,
+    selectedPresetId,
+    selectedSize,
+    trimmedPrompt,
+  ]);
+
+  const validate = useCallback(() => {
+    const nextErrors: PromptFormErrors = {};
+
+    if (!trimmedPrompt) {
+      nextErrors.prompt = 'Enter a prompt to begin generating an image.';
+    } else if (trimmedPrompt.length > maxPromptLength) {
+      nextErrors.prompt = `Prompt must be ${maxPromptLength} characters or fewer.`;
+    }
+
+    if (presets.length > 0 && !selectedPresetId) {
+      nextErrors.enhancementId = 'Choose an enhancement preset to continue.';
+    }
+
+    if (!selectedSize) {
+      nextErrors.size = 'Select an image size.';
+    }
+
+    setErrors(nextErrors);
+    return nextErrors;
+  }, [
+    maxPromptLength,
+    presets.length,
+    selectedPresetId,
+    selectedSize,
+    trimmedPrompt,
+  ]);
+
+  const handlePromptChange = useCallback(
+    (value: string) => {
+      setPrompt(value);
+      setErrors((prev) => ({
+        ...prev,
+        prompt: undefined,
+      }));
+    },
+    [setPrompt],
+  );
+
+  const handlePresetChange = useCallback((value: string) => {
+    setSelectedPresetId(value);
+    setErrors((prev) => ({
+      ...prev,
+      enhancementId: undefined,
+    }));
+  }, []);
+
+  const handleSizeChange = useCallback((option: ImageSizeOption) => {
+    setSelectedSize(option);
+    setErrors((prev) => ({
+      ...prev,
+      size: undefined,
+    }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    (onSubmit: (request: PromptRequestPayload) => void) => {
+      const validation = validate();
+      const hasErrors = Object.keys(validation).length > 0;
+
+      if (hasErrors || !payload) {
+        return false;
+      }
+
+      onSubmit(payload);
+      return true;
+    },
+    [payload, validate],
+  );
+
+  return {
+    prompt,
+    setPrompt: handlePromptChange,
+    selectedPresetId,
+    setSelectedPresetId: handlePresetChange,
+    nanoBanana,
+    setNanoBanana,
+    selectedSize,
+    setSelectedSize: handleSizeChange,
+    errors,
+    validate,
+    enhancedPrompt,
+    payload,
+    maxPromptLength,
+    handleSubmit,
+  };
+};

--- a/src/types/prompt.ts
+++ b/src/types/prompt.ts
@@ -1,0 +1,21 @@
+export interface EnhancementPreset {
+  id: string;
+  label: string;
+  description?: string;
+  promptEnhancement: (prompt: string) => string;
+}
+
+export interface ImageSizeOption {
+  label: string;
+  width: number;
+  height: number;
+}
+
+export interface PromptRequestPayload {
+  prompt: string;
+  basePrompt: string;
+  enhancementId: string | null;
+  nanoBanana: boolean;
+  width: number;
+  height: number;
+}


### PR DESCRIPTION
## Summary
- add a PromptForm component with prompt entry, enhancement selection, Nano Banana toggle, and size controls
- implement a reusable usePromptForm hook to manage validation, preview logic, and Gemini payload assembly
- wire the component into a sample App with example presets and sizes for local testing

## Testing
- not run (project setup not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6a0808c5c83328196c082f7b1274d